### PR TITLE
Build: Add .NET 9 support and validate GenVal App locally

### DIFF
--- a/_config/Directory.Build.props
+++ b/_config/Directory.Build.props
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
     <!-- Set common properties regarding assembly information and nuget packages -->

--- a/gen-val/samples/GenValAppRunner/src/NIST.CVP.ACVTS.Generation.GenValApp.csproj
+++ b/gen-val/samples/GenValAppRunner/src/NIST.CVP.ACVTS.Generation.GenValApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/gen-val/samples/GenValAppRunner/test/NIST.CVP.ACVTS.Libraries.Generation.GenValApp.Tests.csproj
+++ b/gen-val/samples/GenValAppRunner/test/NIST.CVP.ACVTS.Libraries.Generation.GenValApp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/gen-val/samples/NIST.CVP.ACVTS.Orleans.ServerHost/NIST.CVP.ACVTS.Orleans.ServerHost.csproj
+++ b/gen-val/samples/NIST.CVP.ACVTS.Orleans.ServerHost/NIST.CVP.ACVTS.Orleans.ServerHost.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;osx-x64</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <ServerGarbageCollection>true</ServerGarbageCollection>

--- a/gen-val/src/common/src/NIST.CVP.ACVTS.Libraries.Common/NIST.CVP.ACVTS.Libraries.Common.csproj
+++ b/gen-val/src/common/src/NIST.CVP.ACVTS.Libraries.Common/NIST.CVP.ACVTS.Libraries.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 		<Version>$(GenValPackageVersion)</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Project contains enums, extension methods, database helpers, and other various objects for use in the ACVP program.</Description>

--- a/gen-val/src/common/src/NIST.CVP.ACVTS.Libraries.Math/NIST.CVP.ACVTS.Libraries.Math.csproj
+++ b/gen-val/src/common/src/NIST.CVP.ACVTS.Libraries.Math/NIST.CVP.ACVTS.Libraries.Math.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 	<Version>$(GenValPackageVersion)</Version>
   <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   <Description>Project contains math based objects for use in the ACVP project.  Namely: BitString, entropy providers, a shuffle queue, and MathDomain.</Description>

--- a/gen-val/src/common/test/NIST.CVP.ACVTS.Libraries.Common.Tests/NIST.CVP.ACVTS.Libraries.Common.Tests.csproj
+++ b/gen-val/src/common/test/NIST.CVP.ACVTS.Libraries.Common.Tests/NIST.CVP.ACVTS.Libraries.Common.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/common/test/NIST.CVP.ACVTS.Libraries.Math.Tests/NIST.CVP.ACVTS.Libraries.Math.Tests.csproj
+++ b/gen-val/src/common/test/NIST.CVP.ACVTS.Libraries.Math.Tests/NIST.CVP.ACVTS.Libraries.Math.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/common/test/NIST.CVP.ACVTS.Tests.Core/NIST.CVP.ACVTS.Tests.Core.csproj
+++ b/gen-val/src/common/test/NIST.CVP.ACVTS.Tests.Core/NIST.CVP.ACVTS.Tests.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Version>$(GenValPackageVersion)</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>

--- a/gen-val/src/crypto/src/NIST.CVP.ACVTS.Libraries.Crypto.Common/NIST.CVP.ACVTS.Libraries.Crypto.Common.csproj
+++ b/gen-val/src/crypto/src/NIST.CVP.ACVTS.Libraries.Crypto.Common/NIST.CVP.ACVTS.Libraries.Crypto.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 	<Version>$(GenValPackageVersion)</Version>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<Description>ACVP Cryptography abstractions and helper methods.</Description>

--- a/gen-val/src/crypto/src/NIST.CVP.ACVTS.Libraries.Crypto/NIST.CVP.ACVTS.Libraries.Crypto.csproj
+++ b/gen-val/src/crypto/src/NIST.CVP.ACVTS.Libraries.Crypto/NIST.CVP.ACVTS.Libraries.Crypto.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Version>$(GenValPackageVersion)</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>ACVP Cryptography implementations and helper methods.</Description>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_CBC.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_CBC.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_CBC.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_CBC.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_CBC_CTS.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_CBC_CTS.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_CBC_CTS.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_CBC_CTS.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_CBC_MAC.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_CBC_MAC.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_CBC_MAC.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_CBC_MAC.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_CCM.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_CCM.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_CCM.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_CCM.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_CFB1.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_CFB1.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_CFB1.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_CFB1.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_CFB128.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_CFB128.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_CFB128.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_CFB128.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_CFB8.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_CFB8.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_CFB8.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_CFB8.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_CTR.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_CTR.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_CTR.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_CTR.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_ECB.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_ECB.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_ECB.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_ECB.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_FF.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_FF.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_FF.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_FF.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_GCM.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_GCM.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_GCM.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_GCM.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_GCM_SIV.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_GCM_SIV.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_GCM_SIV.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_GCM_SIV.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_OFB.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_OFB.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_OFB.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_OFB.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_XTS.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_XTS.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.AES_XTS.Tests/NIST.CVP.ACVTS.Libraries.Crypto.AES_XTS.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.ANSIX963.Tests/NIST.CVP.ACVTS.Libraries.Crypto.ANSIX963.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.ANSIX963.Tests/NIST.CVP.ACVTS.Libraries.Crypto.ANSIX963.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.ANSX942.Tests/NIST.CVP.ACVTS.Libraries.Crypto.ANSX942.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.ANSX942.Tests/NIST.CVP.ACVTS.Libraries.Crypto.ANSX942.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.Ascon.Tests/NIST.CVP.ACVTS.Libraries.Crypto.Ascon.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.Ascon.Tests/NIST.CVP.ACVTS.Libraries.Crypto.Ascon.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library></OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.BlockCipher_DF.Tests/NIST.CVP.ACVTS.Libraries.Crypto.BlockCipher_DF.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.BlockCipher_DF.Tests/NIST.CVP.ACVTS.Libraries.Crypto.BlockCipher_DF.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.CMAC.Tests/NIST.CVP.ACVTS.Libraries.Crypto.CMAC.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.CMAC.Tests/NIST.CVP.ACVTS.Libraries.Crypto.CMAC.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.CSHAKE.Tests/NIST.CVP.ACVTS.Libraries.Crypto.CSHAKE.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.CSHAKE.Tests/NIST.CVP.ACVTS.Libraries.Crypto.CSHAKE.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.CTR.Tests/NIST.CVP.ACVTS.Libraries.Crypto.CTR.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.CTR.Tests/NIST.CVP.ACVTS.Libraries.Crypto.CTR.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.DRBG.Tests/NIST.CVP.ACVTS.Libraries.Crypto.DRBG.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.DRBG.Tests/NIST.CVP.ACVTS.Libraries.Crypto.DRBG.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.DSA.ECC.Tests/NIST.CVP.ACVTS.Libraries.Crypto.DSA.ECC.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.DSA.ECC.Tests/NIST.CVP.ACVTS.Libraries.Crypto.DSA.ECC.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.DSA.Ed.Tests/NIST.CVP.ACVTS.Libraries.Crypto.DSA.Ed.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.DSA.Ed.Tests/NIST.CVP.ACVTS.Libraries.Crypto.DSA.Ed.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.DSA.FFC.Tests/NIST.CVP.ACVTS.Libraries.Crypto.DSA.FFC.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.DSA.FFC.Tests/NIST.CVP.ACVTS.Libraries.Crypto.DSA.FFC.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.DSA.Tests/NIST.CVP.ACVTS.Libraries.Crypto.DSA.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.DSA.Tests/NIST.CVP.ACVTS.Libraries.Crypto.DSA.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.Dilithium.Tests/NIST.CVP.ACVTS.Libraries.Crypto.Dilithium.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.Dilithium.Tests/NIST.CVP.ACVTS.Libraries.Crypto.Dilithium.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.HKDF.Tests/NIST.CVP.ACVTS.Libraries.Crypto.HKDF.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.HKDF.Tests/NIST.CVP.ACVTS.Libraries.Crypto.HKDF.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.HMAC.Tests/NIST.CVP.ACVTS.Libraries.Crypto.HMAC.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.HMAC.Tests/NIST.CVP.ACVTS.Libraries.Crypto.HMAC.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.Hash_DF.Tests/NIST.CVP.ACVTS.Libraries.Crypto.Hash_DF.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.Hash_DF.Tests/NIST.CVP.ACVTS.Libraries.Crypto.Hash_DF.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.IKEv1.Tests/NIST.CVP.ACVTS.Libraries.Crypto.IKEv1.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.IKEv1.Tests/NIST.CVP.ACVTS.Libraries.Crypto.IKEv1.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.IKEv2.Tests/NIST.CVP.ACVTS.Libraries.Crypto.IKEv2.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.IKEv2.Tests/NIST.CVP.ACVTS.Libraries.Crypto.IKEv2.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.KAS.Tests/NIST.CVP.ACVTS.Libraries.Crypto.KAS.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.KAS.Tests/NIST.CVP.ACVTS.Libraries.Crypto.KAS.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.KDF.Tests/NIST.CVP.ACVTS.Libraries.Crypto.KDF.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.KDF.Tests/NIST.CVP.ACVTS.Libraries.Crypto.KDF.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.KES.Tests/NIST.CVP.ACVTS.Libraries.Crypto.KES.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.KES.Tests/NIST.CVP.ACVTS.Libraries.Crypto.KES.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.KMAC.Tests/NIST.CVP.ACVTS.Libraries.Crypto.KMAC.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.KMAC.Tests/NIST.CVP.ACVTS.Libraries.Crypto.KMAC.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.KeyWrap.Tests/NIST.CVP.ACVTS.Libraries.Crypto.KeyWrap.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.KeyWrap.Tests/NIST.CVP.ACVTS.Libraries.Crypto.KeyWrap.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.Kyber.Tests/NIST.CVP.ACVTS.Libraries.Crypto.Kyber.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.Kyber.Tests/NIST.CVP.ACVTS.Libraries.Crypto.Kyber.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.LMS.Tests/NIST.CVP.ACVTS.Libraries.Crypto.LMS.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.LMS.Tests/NIST.CVP.ACVTS.Libraries.Crypto.LMS.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.MD5.Tests/NIST.CVP.ACVTS.Libraries.Crypto.MD5.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.MD5.Tests/NIST.CVP.ACVTS.Libraries.Crypto.MD5.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.Math.Tests/NIST.CVP.ACVTS.Libraries.Crypto.Math.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.Math.Tests/NIST.CVP.ACVTS.Libraries.Crypto.Math.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject />

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.PBKDF.Tests/NIST.CVP.ACVTS.Libraries.Crypto.PBKDF.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.PBKDF.Tests/NIST.CVP.ACVTS.Libraries.Crypto.PBKDF.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.ParallelHash.Tests/NIST.CVP.ACVTS.Libraries.Crypto.ParallelHash.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.ParallelHash.Tests/NIST.CVP.ACVTS.Libraries.Crypto.ParallelHash.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.RSA.Tests/NIST.CVP.ACVTS.Libraries.Crypto.RSA.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.RSA.Tests/NIST.CVP.ACVTS.Libraries.Crypto.RSA.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.SHA.Tests/NIST.CVP.ACVTS.Libraries.Crypto.SHA.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.SHA.Tests/NIST.CVP.ACVTS.Libraries.Crypto.SHA.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.SLHDSA.Tests/NIST.CVP.ACVTS.Libraries.Crypto.SLHDSA.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.SLHDSA.Tests/NIST.CVP.ACVTS.Libraries.Crypto.SLHDSA.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.SNMP.Tests/NIST.CVP.ACVTS.Libraries.Crypto.SNMP.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.SNMP.Tests/NIST.CVP.ACVTS.Libraries.Crypto.SNMP.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.SP800-106.Tests/NIST.CVP.ACVTS.Libraries.Crypto.SP800-106.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.SP800-106.Tests/NIST.CVP.ACVTS.Libraries.Crypto.SP800-106.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>NIST.CVP.ACVTS.Libraries.Crypto.SP800_106.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.SRTP.Tests/NIST.CVP.ACVTS.Libraries.Crypto.SRTP.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.SRTP.Tests/NIST.CVP.ACVTS.Libraries.Crypto.SRTP.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.SSH.Tests/NIST.CVP.ACVTS.Libraries.Crypto.SSH.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.SSH.Tests/NIST.CVP.ACVTS.Libraries.Crypto.SSH.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.Symmetric.Tests/NIST.CVP.ACVTS.Libraries.Crypto.Symmetric.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.Symmetric.Tests/NIST.CVP.ACVTS.Libraries.Crypto.Symmetric.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CBC.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CBC.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CBC.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CBC.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CBCI.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CBCI.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CBCI.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CBCI.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CFB.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CFB.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CFB.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CFB.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CFBP.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CFBP.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CFBP.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CFBP.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CTR.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CTR.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CTR.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TDES_CTR.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TDES_ECB.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TDES_ECB.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TDES_ECB.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TDES_ECB.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildGenValPackages) == 'false'">

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TDES_OFB.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TDES_OFB.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TDES_OFB.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TDES_OFB.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TDES_OFBI.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TDES_OFBI.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TDES_OFBI.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TDES_OFBI.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TLS.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TLS.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TLS.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TLS.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TPM.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TPM.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TPM.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TPM.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TupleHash.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TupleHash.Tests.csproj
+++ b/gen-val/src/crypto/test/NIST.CVP.ACVTS.Libraries.Crypto.TupleHash.Tests/NIST.CVP.ACVTS.Libraries.Crypto.TupleHash.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation.Core/NIST.CVP.ACVTS.Libraries.Generation.Core.csproj
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation.Core/NIST.CVP.ACVTS.Libraries.Generation.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 	<Version>$(GenValPackageVersion)</Version>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>ACVP Core testing library.  Implementations against this library can be used to generate and validate test vectors against a specific cryptographic algorithm.</Description>

--- a/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/NIST.CVP.ACVTS.Libraries.Generation.csproj
+++ b/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/NIST.CVP.ACVTS.Libraries.Generation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Version>$(GenValPackageVersion)</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Contains runners for generating, validating, and parameter checking test vectors for the ACVP program.</Description>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_CBC.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_CBC.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_CBC.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_CBC.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_CBC_CTS.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_CBC_CTS.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_CBC_CTS.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_CBC_CTS.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_CBC_MAC.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_CBC_MAC.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_CBC_MAC.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_CBC_MAC.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_CCM.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_CCM.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_CCM.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_CCM.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_CFB1.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_CFB1.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_CFB1.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_CFB1.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_CFB128.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_CFB128.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_CFB128.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_CFB128.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_CFB8.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_CFB8.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_CFB8.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_CFB8.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_CTR.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_CTR.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_CTR.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_CTR.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_ECB.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_ECB.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_ECB.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_ECB.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_FF.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_FF.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_FF.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_FF.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_GCM.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_GCM.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_GCM.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_GCM.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_GCM_SIV.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_GCM_SIV.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_GCM_SIV.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_GCM_SIV.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_OFB.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_OFB.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_OFB.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_OFB.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_XPN.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_XPN.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_XPN.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_XPN.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_XTS.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_XTS.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.AES_XTS.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.AES_XTS.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.ANSIX942.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.ANSIX942.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.ANSIX942.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.ANSIX942.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.ANSIX963.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.ANSIX963.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.ANSIX963.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.ANSIX963.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Ascon.AEAD.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.Ascon.AEAD.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Ascon.AEAD.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.Ascon.AEAD.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Ascon.CXOF.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.Ascon.CXOF.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Ascon.CXOF.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.Ascon.CXOF.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Ascon.Hash.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.Ascon.Hash.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Ascon.Hash.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.Ascon.Hash.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Ascon.XOF.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.Ascon.XOF.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Ascon.XOF.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.Ascon.XOF.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.BlockCipher_DF.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.BlockCipher_DF.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.BlockCipher_DF.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.BlockCipher_DF.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.CMAC.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.CMAC.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.CMAC.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.CMAC.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.CSHAKE.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.CSHAKE.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.CSHAKE.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.CSHAKE.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Core.Tests/NIST.CVP.ACVTS.Libraries.Generation.Core.Tests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Core.Tests/NIST.CVP.ACVTS.Libraries.Generation.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DRBG.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DRBG.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DRBG.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DRBG.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.ECC.KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.ECC.KeyGen.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.ECC.KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.ECC.KeyGen.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.ECC.KeyVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.ECC.KeyVer.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.ECC.KeyVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.ECC.KeyVer.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.ECC.SigGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.ECC.SigGen.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.ECC.SigGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.ECC.SigGen.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.ECC.SigVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.ECC.SigVer.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.ECC.SigVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.ECC.SigVer.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.Ed.KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.Ed.KeyGen.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.Ed.KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.Ed.KeyGen.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.Ed.KeyVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.Ed.KeyVer.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.Ed.KeyVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.Ed.KeyVer.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.Ed.SigGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.Ed.SigGen.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.Ed.SigGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.Ed.SigGen.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.Ed.SigVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.Ed.SigVer.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.Ed.SigVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.Ed.SigVer.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.KeyGen.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.KeyGen.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.PQGGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.PQGGen.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.PQGGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.PQGGen.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.PQGVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.PQGVer.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.PQGVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.PQGVer.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.SigGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.SigGen.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.SigGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.SigGen.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.SigVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.SigVer.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.SigVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.DSA.FFC.SigVer.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.HMAC.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.HMAC.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.HMAC.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.HMAC.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.HSS.KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.HSS.KeyGen.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.HSS.KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.HSS.KeyGen.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Hash_DF.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.Hash_DF.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Hash_DF.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.Hash_DF.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.IKEv1.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.IKEv1.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.IKEv1.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.IKEv1.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.IKEv2.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.IKEv2.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.IKEv2.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.IKEv2.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.KAS.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.KAS.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.KAS.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.KAS.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.KDF.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.KDF.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.KDF.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.KDF.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.KMAC.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.KMAC.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.KMAC.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.KMAC.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.KeyWrap.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.KeyWrap.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.KeyWrap.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.KeyWrap.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.LMS.KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.LMS.KeyGen.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.LMS.KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.LMS.KeyGen.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.LMS.SigGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.LMS.SigGen.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.LMS.SigGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.LMS.SigGen.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.LMS.SigVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.LMS.SigVer.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.LMS.SigVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.LMS.SigVer.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.MLDSA.KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.MLDSA.KeyGen.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.MLDSA.KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.MLDSA.KeyGen.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.MLDSA.SigGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.MLDSA.SigGen.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.MLDSA.SigGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.MLDSA.SigGen.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.MLDSA.SigVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.MLDSA.SigVer.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.MLDSA.SigVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.MLDSA.SigVer.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.MLKEM.EncapDecap.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.MLKEM.EncapDecap.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.MLKEM.EncapDecap.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.MLKEM.EncapDecap.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.MLKEM.KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.MLKEM.KeyGen.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.MLKEM.KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.MLKEM.KeyGen.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.PBKDF.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.PBKDF.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.PBKDF.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.PBKDF.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.ParallelHash.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.ParallelHash.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.ParallelHash.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.ParallelHash.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.RSA-DP-SP800-56Br2.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.RSA-DP-SP800-56Br2.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.RSA-DP-SP800-56Br2.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.RSA-DP-SP800-56Br2.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <RootNamespace>NIST.CVP.ACVTS.Libraries.Generation.RSA_DecryptionPrimitive_SP800_56Br2.IntegrationTests</RootNamespace>
     </PropertyGroup>
 

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.RSA-DPComponent.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.RSA-DPComponent.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.RSA-DPComponent.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.RSA-DPComponent.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>NIST.CVP.ACVTS.Libraries.Generation.RSA_DPComponent.IntegrationTests</RootNamespace>
   </PropertyGroup>
 

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.RSA-KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.RSA-KeyGen.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.RSA-KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.RSA-KeyGen.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.RSA-LegacySigVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.RSA-LegacySigVer.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.RSA-LegacySigVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.RSA-LegacySigVer.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.RSA-SPComponent-V2.0.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.RSA-SPComponent-V2.0.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.RSA-SPComponent-V2.0.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.RSA-SPComponent-V2.0.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <RootNamespace>NIST.CVP.ACVTS.Libraries.Generation.RSA_SPComponent_V2_0.IntegrationTests</RootNamespace>
     </PropertyGroup>
 

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.RSA-SPComponent.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.RSA-SPComponent.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.RSA-SPComponent.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.RSA-SPComponent.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>NIST.CVP.ACVTS.Libraries.Generation.RSA_SPComponent.IntegrationTests</RootNamespace>
   </PropertyGroup>
 

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.RSA-SigGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.RSA-SigGen.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.RSA-SigGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.RSA-SigGen.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.RSA-SigVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.RSA-SigVer.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.RSA-SigVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.RSA-SigVer.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.SHA2.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.SHA2.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.SHA2.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.SHA2.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.SHA3.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.SHA3.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.SHA3.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.SHA3.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.SLH-DSA.KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.SLH-DSA.KeyGen.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.SLH-DSA.KeyGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.SLH-DSA.KeyGen.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.SLH-DSA.SigGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.SLH-DSA.SigGen.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.SLH-DSA.SigGen.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.SLH-DSA.SigGen.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.SLH-DSA.SigVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.SLH-DSA.SigVer.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.SLH-DSA.SigVer.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.SLH-DSA.SigVer.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.SNMP.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.SNMP.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.SNMP.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.SNMP.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.SRTP.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.SRTP.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.SRTP.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.SRTP.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.SSH.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.SSH.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.SSH.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.SSH.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TDES_CBC.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TDES_CBC.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TDES_CBC.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TDES_CBC.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TDES_CBCI.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TDES_CBCI.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TDES_CBCI.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TDES_CBCI.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TDES_CFB.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TDES_CFB.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TDES_CFB.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TDES_CFB.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TDES_CFBP.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TDES_CFBP.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TDES_CFBP.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TDES_CFBP.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TDES_CTR.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TDES_CTR.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TDES_CTR.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TDES_CTR.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TDES_ECB.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TDES_ECB.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TDES_ECB.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TDES_ECB.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TDES_OFB.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TDES_OFB.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TDES_OFB.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TDES_OFB.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TDES_OFBI.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TDES_OFBI.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TDES_OFBI.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TDES_OFBI.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TLS.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TLS.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TLS.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TLS.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TLS_v13.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TLS_v13.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TLS_v13.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TLS_v13.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TPM.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TPM.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TPM.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TPM.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Tests/NIST.CVP.ACVTS.Libraries.Generation.Tests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.Tests/NIST.CVP.ACVTS.Libraries.Generation.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TupleHash.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TupleHash.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/NIST.CVP.ACVTS.Libraries.Generation.TupleHash.IntegrationTests/NIST.CVP.ACVTS.Libraries.Generation.TupleHash.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/gen-val/src/generation/test/nist.cvp.acvts.libraries.generation.ascon.integrationtests/NIST.CVP.ACVTS.Libraries.Generation.Ascon.AEAD.IntegrationTests.csproj
+++ b/gen-val/src/generation/test/nist.cvp.acvts.libraries.generation.ascon.integrationtests/NIST.CVP.ACVTS.Libraries.Generation.Ascon.AEAD.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/gen-val/src/oracle/src/NIST.CVP.ACVTS.Libraries.Crypto.Oracle/NIST.CVP.ACVTS.Libraries.Crypto.Oracle.csproj
+++ b/gen-val/src/oracle/src/NIST.CVP.ACVTS.Libraries.Crypto.Oracle/NIST.CVP.ACVTS.Libraries.Crypto.Oracle.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Version>$(GenValPackageVersion)</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Implementations for the gen/val framework interacting with the Orleans cluster.</Description>

--- a/gen-val/src/oracle/src/NIST.CVP.ACVTS.Libraries.Oracle.Abstractions/NIST.CVP.ACVTS.Libraries.Oracle.Abstractions.csproj
+++ b/gen-val/src/oracle/src/NIST.CVP.ACVTS.Libraries.Oracle.Abstractions/NIST.CVP.ACVTS.Libraries.Oracle.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Version>$(GenValPackageVersion)</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Interface for the gen/val framework interacting with the Orleans cluster.</Description>

--- a/gen-val/src/orleans/src/NIST.CVP.ACVTS.Libraries.Orleans.Grains.Interfaces/NIST.CVP.ACVTS.Libraries.Orleans.Grains.Interfaces.csproj
+++ b/gen-val/src/orleans/src/NIST.CVP.ACVTS.Libraries.Orleans.Grains.Interfaces/NIST.CVP.ACVTS.Libraries.Orleans.Grains.Interfaces.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Version>$(GenValPackageVersion)</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Constains interfaces to be implemented for generating/validating cryptographic test cases against an Orleans cluster.</Description>

--- a/gen-val/src/orleans/src/NIST.CVP.ACVTS.Libraries.Orleans.Grains/NIST.CVP.ACVTS.Libraries.Orleans.Grains.csproj
+++ b/gen-val/src/orleans/src/NIST.CVP.ACVTS.Libraries.Orleans.Grains/NIST.CVP.ACVTS.Libraries.Orleans.Grains.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Version>$(GenValPackageVersion)</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Constains implementations for generating/validating cryptographic test cases against an Orleans cluster.</Description>


### PR DESCRIPTION
This PR updates the GenVal application to target .NET 9 and confirms basic local functionality after upgrade.

Fixes Issue #121