### PR TITLE
update to fix merge errors

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -109,12 +109,12 @@ jobs:
     - name: Create Pull Request via GitHub CLI
       if: steps.merge.outputs.conflict != 'true' && steps.merge.outputs.up_to_date != 'true'
       run: |
-           gh pr create \
+           PR_URL=$(gh pr create \
            --repo Katalyst-LLC/nist-ACVP-Server \
            --head sync/upstream-changes \
            --base master \
            --title "Sync from NIST upstream" \
-           --body "This pull request brings in the latest changes from upstream (NIST usnistgov/ACVP-Server)."
+           --body "This pull request brings in the latest changes from upstream (NIST usnistgov/ACVP-Server).")
             echo "Created PR: $PR_URL"
             PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
             echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -121,8 +121,8 @@ jobs:
     - name: Auto-merge Pull Request 
       if: steps.merge.outputs.conflict != 'true' && steps.merge.outputs.up_to_date != 'true'
       run: |
-        sleep 35
-        PR_NUMBER=$(gh pr list --state open --head sync/upstream-changes --json number --jq '.[0].number')
+        sleep 5
+        PR_NUMBER=$(gh pr list --repo Katalyst-LLC/nist-ACVP-Server --state open --head sync/upstream-changes --json number --jq '.[0].number')
         gh pr merge $PR_NUMBER --squash --auto
       env:
         GH_TOKEN: ${{ secrets.PAT_PUSH }}

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -121,6 +121,7 @@ jobs:
     - name: Auto-merge Pull Request 
       if: steps.merge.outputs.conflict != 'true' && steps.merge.outputs.up_to_date != 'true'
       run: |
+        sleep 15
         PR_NUMBER=$(gh pr list --state open --head sync/upstream-changes --json number --jq '.[0].number')
         gh pr merge $PR_NUMBER --squash --auto
       env:

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -94,7 +94,7 @@ jobs:
     
     - name: Show branches and HEAD info
       run: |
-      echo "Current branch: $(git branch --show-current)"
+        echo "Current branch: $(git branch --show-current)"
         git branch -a
         git status
 

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -44,9 +44,10 @@ jobs:
 
     - name: Create sync branch
       if: steps.upstream-check.outputs.has_changes == 'true'
-      run:  |
+      run: |
         git fetch origin master
-        git checkout -b sync/upstream-changes origin/master
+        git checkout origin/master
+        git checkout -B sync/upstream-change
 
     - name: Attempt merge from upstream/master
       if: steps.upstream-check.outputs.has_changes == 'true'
@@ -90,6 +91,12 @@ jobs:
     - name: Exit if no new commits
       if: steps.has-commits.outputs.has_commits != 'true'
       run: echo "No new commits to push. Skipping push and PR."
+    
+    - name: Show branches and HEAD info
+      run: |
+      echo "Current branch: $(git branch --show-current)"
+        git branch -a
+        git status
 
     - name: Push sync branch (force)
       if: steps.merge.outputs.conflict != 'true' && steps.merge.outputs.up_to_date != 'true'

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -109,11 +109,12 @@ jobs:
     - name: Create Pull Request via GitHub CLI
       if: steps.merge.outputs.conflict != 'true' && steps.merge.outputs.up_to_date != 'true'
       run: |
-        gh pr create \
-          --title "Sync from NIST upstream" \
-          --body "This pull request brings in the latest changes from upstream (NIST usnistgov/ACVP-Server)." \
-          --head sync/upstream-changes \
-          --base master
+           gh pr create \
+           --repo Katalyst-LLC/nist-ACVP-Server \
+           --head sync/upstream-changes \
+           --base master \
+           --title "Sync from NIST upstream" \
+           --body "This pull request brings in the latest changes from upstream (NIST usnistgov/ACVP-Server)."
       env:
         GH_TOKEN: ${{ secrets.PAT_PUSH }}
 

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         git fetch origin master
         git checkout origin/master
-        git checkout -B sync/upstream-change
+        git checkout -B sync/upstream-changes
 
     - name: Attempt merge from upstream/master
       if: steps.upstream-check.outputs.has_changes == 'true'

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -44,10 +44,9 @@ jobs:
 
     - name: Create sync branch
       if: steps.upstream-check.outputs.has_changes == 'true'
-      run: |
+      run:  |
         git fetch origin master
-        git checkout origin/master
-        git checkout -B sync/upstream-change
+        git checkout -b sync/upstream-changes origin/master
 
     - name: Attempt merge from upstream/master
       if: steps.upstream-check.outputs.has_changes == 'true'

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -115,14 +115,16 @@ jobs:
            --base master \
            --title "Sync from NIST upstream" \
            --body "This pull request brings in the latest changes from upstream (NIST usnistgov/ACVP-Server)."
+            echo "Created PR: $PR_URL"
+            PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+            echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
       env:
         GH_TOKEN: ${{ secrets.PAT_PUSH }}
 
     - name: Auto-merge Pull Request 
       if: steps.merge.outputs.conflict != 'true' && steps.merge.outputs.up_to_date != 'true'
       run: |
-        sleep 5
-        PR_NUMBER=$(gh pr list --repo Katalyst-LLC/nist-ACVP-Server --state open --head sync/upstream-changes --json number --jq '.[0].number')
-        gh pr merge $PR_NUMBER --squash --auto
+        echo "Merging PR #${{ steps.create_pr.outputs.pr_number }}"
+        gh pr merge ${{ steps.create_pr.outputs.pr_number }} --repo Katalyst-LLC/nist-ACVP-Server --squash --auto
       env:
         GH_TOKEN: ${{ secrets.PAT_PUSH }}

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -73,13 +73,29 @@ jobs:
         echo "::error ::Merge conflict detected. Manual resolution required."
         exit 1
 
-    - name: Push changes to remote
+    - name: Check if sync branch has new commits
+      id: has-commits
+      run: |
+        git fetch origin master
+        COMMITS=$(git rev-list origin/master..HEAD --count)
+        echo "Commits ahead: $COMMITS"
+        if [ "$COMMITS" -eq 0 ]; then
+          echo "has_commits=false" >> $GITHUB_OUTPUT
+        else
+          echo "has_commits=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Exit if no new commits
+      if: steps.has-commits.outputs.has_commits != 'true'
+      run: echo "No new commits to push. Skipping push and PR."
+
+    - name: Push sync branch (force)
       if: steps.merge.outputs.conflict != 'true' && steps.merge.outputs.up_to_date != 'true'
       env:
         PAT_PUSH: ${{ secrets.PAT_PUSH }}
       run: |
         git remote set-url origin https://x-access-token:${PAT_PUSH}@github.com/${{ github.repository }}
-        git push origin sync/upstream-changes
+        git push --force origin sync/upstream-changes
 
     - name: Create Pull Request via GitHub CLI
       if: steps.merge.outputs.conflict != 'true' && steps.merge.outputs.up_to_date != 'true'

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -121,7 +121,7 @@ jobs:
     - name: Auto-merge Pull Request 
       if: steps.merge.outputs.conflict != 'true' && steps.merge.outputs.up_to_date != 'true'
       run: |
-        sleep 15
+        sleep 35
         PR_NUMBER=$(gh pr list --state open --head sync/upstream-changes --json number --jq '.[0].number')
         gh pr merge $PR_NUMBER --squash --auto
       env:

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -107,6 +107,7 @@ jobs:
         git push --force origin sync/upstream-changes
 
     - name: Create Pull Request via GitHub CLI
+      id: create_pr
       if: steps.merge.outputs.conflict != 'true' && steps.merge.outputs.up_to_date != 'true'
       run: |
            PR_URL=$(gh pr create \

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -44,7 +44,10 @@ jobs:
 
     - name: Create sync branch
       if: steps.upstream-check.outputs.has_changes == 'true'
-      run: git checkout -B sync/upstream-changes
+      run: |
+        git fetch origin master
+        git checkout origin/master
+        git checkout -B sync/upstream-change
 
     - name: Attempt merge from upstream/master
       if: steps.upstream-check.outputs.has_changes == 'true'


### PR DESCRIPTION

Error:
Run git remote set-url origin [https://x-access-token:${PAT_PUSH}@github.com/Katalyst-LLC/nist-ACVP-Server](https://x-access-token:$%7BPAT_PUSH%7D@github.com/Katalyst-LLC/nist-ACVP-Server)

To https://github.com/Katalyst-LLC/nist-ACVP-Server
! [rejected] sync/upstream-changes -> sync/upstream-changes (non-fast-forward)
error: failed to push some refs to 'https://github.com/Katalyst-LLC/nist-ACVP-Server'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. If you want to integrate the remote changes,
hint: use 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: Process completed with exit code 1.