### PR TITLE
[BUG] Unable to Deploy Docker Images due to Access Token Permissions? #61

### DIFF
--- a/.github/workflows/genval.yml
+++ b/.github/workflows/genval.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'gen-val/**'
     branches:
-      - '*'  
+      - '**'  
   pull_request:
     paths:
       - 'gen-val/**'
@@ -87,8 +87,8 @@ jobs:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       run: |
-        docker tag katalyst/genval:latest ${{ secrets.DOCKER_REGISTRY }}/katalyst-llc/genval:latest
-        docker push ${{ secrets.DOCKER_REGISTRY }}/katalyst-llc/genval:latest
+        docker tag katalyst/genval:latest ghcr.io/katalyst-llc/genval:latest
+        docker push ghcr.io/katalyst-llc/genval:latest
 
     - name: Notify on Success
       if: success()

--- a/.github/workflows/genval.yml
+++ b/.github/workflows/genval.yml
@@ -86,8 +86,8 @@ jobs:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       run: |
-        docker tag katalyst/genval:latest ${{ secrets.DOCKER_REGISTRY }}/katalyst-llc/genval:latest
-        docker push ${{ secrets.DOCKER_REGISTRY }}/katalyst-llc/genval:latest
+        docker tag katalyst/genval:latest ghcr.io/katalyst-llc/genval:latest
+        docker push ghcr.io/katalyst-llc/genval:latest
 
     - name: Notify on Success
       if: success()

--- a/.github/workflows/genval.yml
+++ b/.github/workflows/genval.yml
@@ -87,8 +87,8 @@ jobs:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       run: |
-        docker tag katalyst/genval:latest ghcr.io/katalyst-llc/genval:latest
-        docker push ghcr.io/katalyst-llc/genval:latest
+        docker tag katalyst/genval:latest ${{ secrets.DOCKER_REGISTRY }}/katalyst-llc/genval:latest
+        docker push ${{ secrets.DOCKER_REGISTRY }}/katalyst-llc/genval:latest
 
     - name: Notify on Success
       if: success()

--- a/.github/workflows/genval.yml
+++ b/.github/workflows/genval.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'gen-val/**'
     branches:
-      - master
+      - '*'
   pull_request:
     paths:
       - 'gen-val/**'

--- a/.github/workflows/genval.yml
+++ b/.github/workflows/genval.yml
@@ -5,10 +5,11 @@ on:
     paths:
       - 'gen-val/**'
     branches:
-      - '*'
+      - '*'  
   pull_request:
     paths:
       - 'gen-val/**'
+  workflow_dispatch:
 
 jobs:
   build-and-test:

--- a/gen-val/samples/GenValAppRunner/src/Controller/AlgorithmsController.cs
+++ b/gen-val/samples/GenValAppRunner/src/Controller/AlgorithmsController.cs
@@ -14,7 +14,7 @@ namespace GenValApp.Controllers
         {}
 
         [HttpGet()]
-        public IActionResult GetSupportedAlgorithms()
+        public IActionResult GetSupportedAlgorithms() 
         {
             try
             {


### PR DESCRIPTION
Unable to Deploy Docker Images due to Access Token Permissions

It would still seem we are failing to successfully deploy our GenVal App on .Net on a Docker Image due to some kind of Github Access Token permissions problem. We need to solve this problem, determine what type of Token / Permissions for successfully deploy the GenVal App to a linux-based Docker Image.

If a Katalyst Organization Personal Access Token is needed, @DewSecGitHub will be ready to provide as instructed.